### PR TITLE
Correção no metodo isAvailablePlugin

### DIFF
--- a/PushNotification.js
+++ b/PushNotification.js
@@ -54,16 +54,7 @@ Ext.define('Mba.ux.PushNotification', {
      * @returns {boolean}
      */
     isAvailablePlugin: function() {
-        var isCordovaPluginInstaled = true;
-        if (!window.plugins) {
-            isCordovaPluginInstaled = false;
-        }
-
-        if (!window.plugins.pushNotification) {
-            isCordovaPluginInstaled = false;
-        }
-
-        return isCordovaPluginInstaled;
+        return (window.plugins && window.plugins.pushNotification);
     },
 
     /**


### PR DESCRIPTION
Caso a primeira verificação do window.plugins de falso, na segunda verificação, o window.plugins está undefined, e ocorre erro no console.
